### PR TITLE
Potential fix for code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/com/mglo/game/model/Player.java
+++ b/src/com/mglo/game/model/Player.java
@@ -7,15 +7,16 @@ import java.awt.*;
 
 public class Player {
     private float x,y;
-    private int width, height, velY;
+    private int width, height;
+    private float velY;
     private Rectangle rect, duckRect, ground;
 
     private boolean isAlive;
     private boolean isDucked;
     private float duckDuration = .6f;
 
-    private static final int JUMP_VELOCITY = -600;
-    private static final int ACCEL_GRAVITY = 1800;
+    private static final float JUMP_VELOCITY = -600f;
+    private static final float ACCEL_GRAVITY = 1800f;
 
     public Player(float x, float y, int width, int height) {
         this.x = x;
@@ -104,7 +105,7 @@ public class Player {
     }
 
     public int getVelY() {
-        return velY;
+        return (int) velY;
     }
 
     public Rectangle getRect() {


### PR DESCRIPTION
Potential fix for [https://github.com/mateuszglowa/SimplaJavaGDF/security/code-scanning/1](https://github.com/mateuszglowa/SimplaJavaGDF/security/code-scanning/1)

In general, to fix this kind of issue you ensure that the left-hand side of a compound assignment has a type at least as wide/precise as the right-hand side expression. For numeric game-physics code, that typically means using `float` or `double` consistently for quantities like velocity, acceleration, and time step, rather than narrowing them to integers.

Here, the best fix without changing intended functionality is:

- Change `velY` from `int` to `float`.
- Change the related constants `JUMP_VELOCITY` and `ACCEL_GRAVITY` to `float` so all computations involving `delta` stay in `float` space.
- Keep the public API largely intact by having `getVelY()` still return an `int`, but derived from the internal `float velY` via an explicit cast. This preserves callers that expect an `int` while making the internal physics continuous and removing the implicit narrowing.
- All existing assignments (`velY = 0;`, `velY = JUMP_VELOCITY;`) and updates (`velY += ACCEL_GRAVITY * delta;`) will then operate in `float`, eliminating the CodeQL warning.

Concretely, in `src/com/mglo/game/model/Player.java`:

- Line 10: change `velY` to `float`.
- Lines 17–18: change `JUMP_VELOCITY` and `ACCEL_GRAVITY` to `float` literals.
- Line 106–107: adjust `getVelY()` to cast the internal `float` to `int` for return.

No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
